### PR TITLE
MessageUI framework should be optional, otherwise it won't link

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,6 @@
         </config-file>
         <header-file src="src/ios/Sms.h" />
         <source-file src="src/ios/Sms.m" />
-        <framework src="MessageUI.framework" />
+        <framework src="MessageUI.framework" weak="true" />
     </platform> 
 </plugin>


### PR DESCRIPTION
I got the following error using a required MessageUI.framework:
Undefined symbols for architecture armv7:
  "_OBJC_CLASS_$_MFMessageComposeViewController"

Switching to optional fixed that.
