### PR TITLE
Attempting compatibility with phonegap build

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+        xmlns:android="http://schemas.android.com/apk/res/android"
            id="org.apache.cordova.plugin.sms"
       version="0.1.0">
     <name>Sms</name>


### PR DESCRIPTION
Hi,

Your plugin.xml looks fine, but maybe phonegap build has trouble with the missing engines tag (I know it's an optional tag, but your plugin doesn't seem to support 2.9 and lower, so it's a good idea to include it anyway).

Hope this helps.. let me know,
Eddy
