### PR TITLE
Fixed issue with warning thrown in Cordova 4.0.0 for iOS.

### DIFF
--- a/src/ios/Sms.m
+++ b/src/ios/Sms.m
@@ -73,13 +73,15 @@
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
     
     if(webviewResult == 1) {
-        [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                  messageAsString:message]
-                                toSuccessCallbackString:self.callbackID]];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                          messageAsString:message];
+        
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackID];
     } else {
-        [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                  messageAsString:message]
-                                toErrorCallbackString:self.callbackID]];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                          messageAsString:message];
+
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackID];
     }
 }
 


### PR DESCRIPTION
Getting warning with new Cordova 4.0.0 on iOS. writeJavascript is deprecated in Cordova 4.0.0.
